### PR TITLE
Small mobile style cleanups

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -42,12 +42,10 @@
   "devDependencies": {
     "@types/react": "^16.9.53"
   },
-
   "eslintConfig": {
     "extends": "react-app",
     "rules": {
       "import/no-anonymous-default-export": 0
     }
   }
-
 }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -3,13 +3,26 @@ import ReactDOM from 'react-dom';
 import App from './modules/App/App';
 import * as serviceWorker from './serviceWorker';
 import { ThemeProvider } from '@material-ui/core/styles';
-import { ThemeProvider as StyledThemeProvider } from "styled-components";
+import { ThemeProvider as StyledThemeProvider, createGlobalStyle } from "styled-components";
 import theme from './theme';
+
+const GlobalStyles = createGlobalStyle`
+  * {
+    box-sizing: border-box;
+  };
+
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+  };
+`;
 
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <StyledThemeProvider theme={theme}>
+        <GlobalStyles />
         <App />
       </StyledThemeProvider>
     </ThemeProvider>

--- a/client/src/modules/App/App.tsx
+++ b/client/src/modules/App/App.tsx
@@ -58,9 +58,12 @@ const InnerSectionContainer = styled.div`
 
 const Section = styled.section`
   width: 50%;
-  min-width: 600px;
   display: flex;
   flex-direction: column;
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
 `;
 
 const LeftSection = styled(Section)``;


### PR DESCRIPTION
This PR adds Styled Components' `createGlobalStyle` to add some basic global styles to the app...

1. `* { box-sizing: border-box; }` resets the calculations for elements in the app, making it much easier to properly size things. [More info](https://css-tricks.com/box-sizing/#present-day-box-sizing)
2. Margin and padding resets on top-level elements. Just to get rid of some default spacing.
3. Removed the 600px min width (since that is what was causing the overflow on smaller screens. Replaced it with a media query to make sure those columns wrap once you get smaller than 768px.