### PR TITLE
create state store for Download button

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - run: npm install && npm run build --prefix client
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ build/
 .env.development.local
 .env.test.local
 .env.production.local
+.workspace.xml

--- a/client/src/modules/Download/Download.component.tsx
+++ b/client/src/modules/Download/Download.component.tsx
@@ -3,24 +3,41 @@ import Fab from '../../components/Fab';
 import ChaptersStore from '../../modules/Chapters/Chapters.store';
 import DetailsStore from '../../modules/BookDetails/BookDetails.store';
 import * as DownloadSupport from './Download.support';
+import DownloadStore from './Download.store';
+import withObserver from "../../hocs/withObserver";
 
 // We only need to access the store on click so this component doesn't
 // have to observe the store
 const { sharedInstance: chaptersStore } = ChaptersStore;
 const { sharedInstance: detailsStore } = DetailsStore;
 
-const Download = () => {
-  //
-  const handleDownload = () => {
-    DownloadSupport.downloadEbookFromRedditSources(
+const Download = (props: IDownloadProps) => {
+  const { store } = props;
+
+  const handleDownload = async () => {
+    store.setIsLoading(true);
+    await DownloadSupport.downloadEbookFromRedditSources(
       detailsStore.title,
       detailsStore.author,
       'https://www.redditstatic.com/icon.png',
       chaptersStore.chapters
-    )
+    );
+    store.setIsLoading(false);
   };
   //
-  return <Fab onClick={handleDownload}>Download eBook</Fab>
+  return (
+    <Fab
+      onClick={handleDownload}
+      disabled={store.isLoading}
+    >
+      { store.isLoading ? 'Generating...' : 'Download eBook' }
+    </Fab>
+  )
 };
 
-export default Download;
+export default withObserver(Download, DownloadStore.sharedInstance);
+
+// TYPES
+export interface IDownloadProps {
+  store: DownloadStore
+}

--- a/client/src/modules/Download/Download.store.ts
+++ b/client/src/modules/Download/Download.store.ts
@@ -1,0 +1,21 @@
+import {makeAutoObservable} from "mobx";
+
+export default class DownloadStore {
+
+  static sharedInstance: DownloadStore = new DownloadStore();
+
+  //
+  // OBSERVABLES
+  isLoading: boolean = false;
+
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  //
+  // ACTIONS
+  //
+  setIsLoading = (isLoading: boolean) => this.isLoading = isLoading;
+
+}


### PR DESCRIPTION
Needed to keep track of an "isLoading" state to disabled and change the text of the Download Fab. So far, all the state in the app is managed in MobX stores so I'm keeping the same pattern.